### PR TITLE
register null authenticator with entrypoints

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,12 @@ setup_args = dict(
     ],
     cmdclass={
         'bdist_egg': bdist_egg if 'bdist_egg' in sys.argv else bdist_egg_disabled,
-    }
+    },
+    entry_points={
+        "jupyterhub.authenticators": [
+            "null = nullauthenticator:NullAuthenticator",
+        ],
+    },
 )
 
 setup_args['install_requires'] = install_requires = []


### PR DESCRIPTION
allows it to be advertised in autogenerated config, selected by short name