### PR TITLE
docs: PyPI badge in README to point to the right repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # NullAuthenticator
 
-[![PyPI](https://img.shields.io/pypi/v/nine.svg)](https://github.com/jupyterhub/nullauthenticator)
+[![PyPI](https://img.shields.io/pypi/v/nullauthenticator.svg)](https://pypi.org/project/nullauthenticator/)
 
 
 Null Authenticator for JupyterHub instances that should have no login mechanism,


### PR DESCRIPTION
I became confused seeing version `1.1.0` being mentioned in the PyPI badge part of the readme, but `1.0.0` was the version available on PyPI. It was because the badge pointed to the wrong repo.